### PR TITLE
Add Laterality enum and region_coverage to ProjectionMeasurementMatrix

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,6 +2,8 @@ FROM condaforge/miniforge3:26.1.1-2
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+RUN apt-get update && apt-get install -y bash-completion && rm -rf /var/lib/apt/lists/*
+
 RUN conda install -y \
         jupyterlab==4.4.10 \
     && conda clean -ya
@@ -22,3 +24,5 @@ RUN pip install -U --no-cache-dir \
     seaborn==0.13.2 \
     standard-transform==1.4.1 \
     umap-learn==0.5.9.post2
+
+RUN pip install -U --no-cache-dir uv

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,24 @@
+FROM condaforge/miniforge3:26.1.1-2
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN conda install -y \
+        jupyterlab==4.4.10 \
+    && conda clean -ya
+
+RUN pip install -U --no-cache-dir \
+    caveclient==8.0.0 \
+    deltalake==1.2.1 \
+    ipywidgets==8.1.8 \
+    linkml==1.9.5 \
+    linkml-runtime==1.9.5 \
+    matplotlib==3.10.7 \
+    pandas==2.3.3 \
+    polars==1.34.0 \
+    pyarrow==22.0.0 \
+    pydantic==2.12.3 \
+    pyyaml \
+    scikit-learn==1.7.2 \
+    seaborn==0.13.2 \
+    standard-transform==1.4.1 \
+    umap-learn==0.5.9.post2

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,10 +9,14 @@
     "source=${localWorkspaceFolder}/results,target=/results,type=bind"
   ],
   "postStartCommand": "pip install -e /workspaces/ConnectsCommonConnectivity",
+  "postCreateCommand": "sed -i '/bash_completion/s/^#//' ~/.bashrc && sed -i 's/^#fi$/fi/' ~/.bashrc && grep -q 'completions/git' ~/.bashrc || echo 'source /usr/share/bash-completion/completions/git 2>/dev/null' >> ~/.bashrc",
   "runArgs": ["--env-file", "${localWorkspaceFolder}/.env"],
   "customizations": {
     "vscode": {
-      "extensions": ["ms-python.python", "ms-toolsai.jupyter"]
+      "extensions": ["ms-python.python", "ms-toolsai.jupyter"],
+      "settings": {
+        "python.defaultInterpreterPath": "/opt/conda/bin/python"
+      }
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "name": "CCC",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "mounts": [
+    "source=${localWorkspaceFolder}/data,target=/data,type=bind",
+    "source=${localWorkspaceFolder}/results,target=/results,type=bind"
+  ],
+  "postStartCommand": "pip install -e /workspaces/ConnectsCommonConnectivity",
+  "runArgs": ["--env-file", "${localWorkspaceFolder}/.env"],
+  "customizations": {
+    "vscode": {
+      "extensions": ["ms-python.python", "ms-toolsai.jupyter"]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+environment/git-askpass
 
 # Spyder project settings
 .spyderproject

--- a/environment/postInstall
+++ b/environment/postInstall
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
 set -e
+pip install -e /root/capsule

--- a/schemas/base_schema.yaml
+++ b/schemas/base_schema.yaml
@@ -88,6 +88,17 @@ enums:
         description: Binary unit (0 or 1).
       NONE:
         description: Dimensionless.
+  Laterality:
+    description: Hemisphere laterality relative to the injection or soma site.
+    permissible_values:
+      IPSILATERAL:
+        description: Projection is on the same side as the injection/soma.
+      CONTRALATERAL:
+        description: Projection is on the opposite side from the injection/soma.
+      BILATERAL:
+        description: Projection spans both hemispheres.
+      UNKNOWN:
+        description: Laterality is not known or not applicable.
 
 slots:
   id:
@@ -119,6 +130,9 @@ slots:
   unit:
     description: Unit of measure for values.
     range: Unit
+  laterality:
+    description: Laterality of the measurement (ipsilateral or contralateral).
+    range: Laterality
   cell_index:
     range: DataItem
     description: Ordered list of cells indexing a matrix.

--- a/schemas/projection_schema.yaml
+++ b/schemas/projection_schema.yaml
@@ -27,6 +27,7 @@ classes:
       - description
       - measurement_type
       - modality
+      - laterality
       - region_index
       - data_item_index
       - values
@@ -51,6 +52,10 @@ classes:
         description: Zarr array containing matrix values with shape (data_item_index x region_index).
       unit:
         range: Unit
+      laterality:
+        range: Laterality
+        required: true
+        description: Whether this matrix represents ipsilateral, contralateral, bilateral, or unknown projections.
 
 
 slots:

--- a/schemas/projection_schema.yaml
+++ b/schemas/projection_schema.yaml
@@ -29,6 +29,7 @@ classes:
       - modality
       - laterality
       - region_index
+      - region_coverage
       - data_item_index
       - values
       - unit
@@ -42,6 +43,11 @@ classes:
         range: BrainRegion
         inlined: false
         description: Ordered regions defining columns (or rows) of the matrix.
+      region_coverage:
+        multivalued: true
+        range: BrainRegion
+        inlined: false
+        description: Precomputed subset of region_index where at least one data item has a non-zero value. Enables fast lookup of which regions have projection data without loading the full matrix.
       data_item_index:
         multivalued: true
         range: DataItem
@@ -63,6 +69,10 @@ slots:
     description: The specific projection measurement type (enum) for this set.
   region_index:
     description: Ordered list of regions indexing a matrix or values vector.
+  region_coverage:
+    description: Subset of region_index with non-zero projection data for at least one data item.
+    range: BrainRegion
+    multivalued: true
   data_item_index:
     description: Ordered list of data items indexing a matrix.
   values:

--- a/src/connects_common_connectivity/io/io_plans.md
+++ b/src/connects_common_connectivity/io/io_plans.md
@@ -1,0 +1,36 @@
+# IO Utility Functions — Plans
+
+## `populate_region_coverage(pmm, matrix) → ProjectionMeasurementMatrix`
+
+Automatically populates the `region_coverage` field on a `ProjectionMeasurementMatrix` from the dense values array.
+
+- **Input:**
+  - `pmm`: a `ProjectionMeasurementMatrix` instance with `region_index` already set.
+  - `matrix`: dense numeric array of shape `(len(data_item_index), len(region_index))` — numpy ndarray or similar.
+- **Logic:** For each column index `i`, check `any(matrix[:, i] != 0)`. Collect the corresponding `pmm.region_index[i]` entries where the column has at least one non-zero value.
+- **Output:** Returns a copy of `pmm` with `region_coverage` set to the non-zero-column subset of `region_index`.
+- **Properties:** Pure function, no side effects. Does not modify the input `pmm`.
+
+---
+
+## `compare_region_coverage(pmms) → dict`
+
+Compares region index and region coverage across multiple `ProjectionMeasurementMatrix` instances. Answers: "which regions are shared, and which are exclusive to specific dataset combinations?"
+
+- **Input:**
+  - `pmms`: list of `ProjectionMeasurementMatrix` instances, each with `region_index` and `region_coverage` populated.
+- **Computes:**
+  - `shared_regions`: intersection of all `region_index` across inputs (what regions can we compare at all?).
+  - `shared_coverage`: intersection of all `region_coverage` across inputs (where do all datasets have signal?).
+  - For every non-empty subset of the input PMMs (powerset, size 1 through N): count of regions that are in that subset's `region_coverage` intersection but **not** in any other PMM's `region_coverage` (exclusive to that combination).
+- **Prints:** A summary table showing, for each subset combination, how many regions are exclusively covered by that combination. Example for 3 datasets A, B, C:
+  ```
+  Only in A:           12
+  Only in B:            5
+  Only in C:            8
+  Only in A ∩ B:        3
+  Only in A ∩ C:        2
+  Only in B ∩ C:        1
+  In all (A ∩ B ∩ C):  45
+  ```
+- **Returns:** dict with keys `shared_regions`, `shared_coverage`, and `exclusive_counts` (mapping subset labels to region counts).

--- a/src/connects_common_connectivity/models.py
+++ b/src/connects_common_connectivity/models.py
@@ -230,6 +230,28 @@ class Unit(str, Enum):
     """
 
 
+class Laterality(str, Enum):
+    """
+    Hemisphere laterality relative to the injection or soma site.
+    """
+    IPSILATERAL = "IPSILATERAL"
+    """
+    Projection is on the same side as the injection/soma.
+    """
+    CONTRALATERAL = "CONTRALATERAL"
+    """
+    Projection is on the opposite side from the injection/soma.
+    """
+    BILATERAL = "BILATERAL"
+    """
+    Projection spans both hemispheres.
+    """
+    UNKNOWN = "UNKNOWN"
+    """
+    Laterality is not known or not applicable.
+    """
+
+
 
 class SpatialLocation(ConfiguredBaseModel):
     """
@@ -1030,6 +1052,13 @@ class ProjectionMeasurementMatrix(ConfiguredBaseModel):
                                             'multivalued': True,
                                             'name': 'data_item_index',
                                             'range': 'DataItem'},
+                        'laterality': {'description': 'Whether this matrix represents '
+                                                      'ipsilateral, contralateral, '
+                                                      'bilateral, or unknown '
+                                                      'projections.',
+                                       'name': 'laterality',
+                                       'range': 'Laterality',
+                                       'required': True},
                         'measurement_type': {'name': 'measurement_type',
                                              'range': 'ProjectionMeasurementType'},
                         'modality': {'name': 'modality', 'range': 'Modality'},
@@ -1089,6 +1118,7 @@ class ProjectionMeasurementMatrix(ConfiguredBaseModel):
                        'ProjectionMeasurementMatrix',
                        'CellCellConnectivityLong',
                        'CellCellMeasurementMatrix']} })
+    laterality: Laterality = Field(default=..., description="""Whether this matrix represents ipsilateral, contralateral, bilateral, or unknown projections.""", json_schema_extra = { "linkml_meta": {'alias': 'laterality', 'domain_of': ['ProjectionMeasurementMatrix']} })
     region_index: Optional[list[str]] = Field(default=None, description="""Ordered regions defining columns (or rows) of the matrix.""", json_schema_extra = { "linkml_meta": {'alias': 'region_index', 'domain_of': ['ProjectionMeasurementMatrix']} })
     data_item_index: Optional[list[str]] = Field(default=None, description="""Ordered data items defining rows (or columns) of the matrix.""", json_schema_extra = { "linkml_meta": {'alias': 'data_item_index', 'domain_of': ['ProjectionMeasurementMatrix']} })
     values: Optional[str] = Field(default=None, description="""Zarr array containing matrix values with shape (data_item_index x region_index).""", json_schema_extra = { "linkml_meta": {'alias': 'values',

--- a/src/connects_common_connectivity/models.py
+++ b/src/connects_common_connectivity/models.py
@@ -1062,6 +1062,18 @@ class ProjectionMeasurementMatrix(ConfiguredBaseModel):
                         'measurement_type': {'name': 'measurement_type',
                                              'range': 'ProjectionMeasurementType'},
                         'modality': {'name': 'modality', 'range': 'Modality'},
+                        'region_coverage': {'description': 'Precomputed subset of '
+                                                           'region_index where at '
+                                                           'least one data item has a '
+                                                           'non-zero value. Enables '
+                                                           'fast lookup of which '
+                                                           'regions have projection '
+                                                           'data without loading the '
+                                                           'full matrix.',
+                                            'inlined': False,
+                                            'multivalued': True,
+                                            'name': 'region_coverage',
+                                            'range': 'BrainRegion'},
                         'region_index': {'description': 'Ordered regions defining '
                                                         'columns (or rows) of the '
                                                         'matrix.',
@@ -1120,6 +1132,7 @@ class ProjectionMeasurementMatrix(ConfiguredBaseModel):
                        'CellCellMeasurementMatrix']} })
     laterality: Laterality = Field(default=..., description="""Whether this matrix represents ipsilateral, contralateral, bilateral, or unknown projections.""", json_schema_extra = { "linkml_meta": {'alias': 'laterality', 'domain_of': ['ProjectionMeasurementMatrix']} })
     region_index: Optional[list[str]] = Field(default=None, description="""Ordered regions defining columns (or rows) of the matrix.""", json_schema_extra = { "linkml_meta": {'alias': 'region_index', 'domain_of': ['ProjectionMeasurementMatrix']} })
+    region_coverage: Optional[list[str]] = Field(default=None, description="""Precomputed subset of region_index where at least one data item has a non-zero value. Enables fast lookup of which regions have projection data without loading the full matrix.""", json_schema_extra = { "linkml_meta": {'alias': 'region_coverage', 'domain_of': ['ProjectionMeasurementMatrix']} })
     data_item_index: Optional[list[str]] = Field(default=None, description="""Ordered data items defining rows (or columns) of the matrix.""", json_schema_extra = { "linkml_meta": {'alias': 'data_item_index', 'domain_of': ['ProjectionMeasurementMatrix']} })
     values: Optional[str] = Field(default=None, description="""Zarr array containing matrix values with shape (data_item_index x region_index).""", json_schema_extra = { "linkml_meta": {'alias': 'values',
          'domain_of': ['ProjectionMeasurementMatrix', 'CellCellMeasurementMatrix']} })

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -100,3 +100,25 @@ def test_projection_measurement_matrix_laterality():
         PMM(id="P2", measurement_type=PMType.NUMBER_OF_TIPS,
             modality=Modality.MORPHOLOGY, laterality="NOT_VALID")
 
+
+def test_region_coverage_on_pmm():
+    import connects_common_connectivity as ccc
+    models = ccc.generate_pydantic_models()
+    PMM = models["ProjectionMeasurementMatrix"]
+    Laterality = models["Laterality"]
+    Modality = models["Modality"]
+    PMType = models["ProjectionMeasurementType"]
+    # region_coverage is optional — PMM without it should validate
+    pmm_no_cov = PMM(id="P1", measurement_type=PMType.NUMBER_OF_TIPS,
+                      modality=Modality.MORPHOLOGY, laterality=Laterality.IPSILATERAL,
+                      region_index=["R1", "R2", "R3"])
+    assert pmm_no_cov.region_coverage is None
+    # PMM with region_coverage as subset of region_index
+    pmm_with_cov = PMM(id="P2", measurement_type=PMType.NUMBER_OF_TIPS,
+                        modality=Modality.MORPHOLOGY, laterality=Laterality.CONTRALATERAL,
+                        region_index=["R1", "R2", "R3"],
+                        region_coverage=["R1", "R2"])
+    assert isinstance(pmm_with_cov.region_coverage, list)
+    assert len(pmm_with_cov.region_coverage) == 2
+    assert set(pmm_with_cov.region_coverage).issubset(set(pmm_with_cov.region_index))
+

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -69,3 +69,34 @@ def test_probability_bounds_and_pattern():
     with pytest.raises(Exception):
         CellToCellMapping(id="M2", mapping_set=ms.id, source_cell=cell1.id, target_cell=cell2.id, probability=1.5, project_id="P1")
 
+
+def test_laterality_enum():
+    import connects_common_connectivity as ccc
+    models = ccc.generate_pydantic_models()
+    Laterality = models["Laterality"]
+    assert Laterality.IPSILATERAL.name == "IPSILATERAL"
+    assert Laterality.CONTRALATERAL.name == "CONTRALATERAL"
+    assert Laterality.BILATERAL.name == "BILATERAL"
+    assert Laterality.UNKNOWN.name == "UNKNOWN"
+
+
+def test_projection_measurement_matrix_laterality():
+    import pytest
+    import connects_common_connectivity as ccc
+    models = ccc.generate_pydantic_models()
+    PMM = models["ProjectionMeasurementMatrix"]
+    Laterality = models["Laterality"]
+    Modality = models["Modality"]
+    PMType = models["ProjectionMeasurementType"]
+    # laterality is required; omitting it should raise
+    with pytest.raises(Exception):
+        PMM(id="P1", measurement_type=PMType.NUMBER_OF_TIPS, modality=Modality.MORPHOLOGY)
+    # Valid laterality values accepted
+    pmm = PMM(id="P1", measurement_type=PMType.NUMBER_OF_TIPS,
+              modality=Modality.MORPHOLOGY, laterality=Laterality.IPSILATERAL)
+    assert str(pmm.laterality) in {Laterality.IPSILATERAL.value, Laterality.IPSILATERAL.name, str(Laterality.IPSILATERAL)}
+    # Invalid laterality should raise
+    with pytest.raises(Exception):
+        PMM(id="P2", measurement_type=PMType.NUMBER_OF_TIPS,
+            modality=Modality.MORPHOLOGY, laterality="NOT_VALID")
+

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -70,55 +70,5 @@ def test_probability_bounds_and_pattern():
         CellToCellMapping(id="M2", mapping_set=ms.id, source_cell=cell1.id, target_cell=cell2.id, probability=1.5, project_id="P1")
 
 
-def test_laterality_enum():
-    import connects_common_connectivity as ccc
-    models = ccc.generate_pydantic_models()
-    Laterality = models["Laterality"]
-    assert Laterality.IPSILATERAL.name == "IPSILATERAL"
-    assert Laterality.CONTRALATERAL.name == "CONTRALATERAL"
-    assert Laterality.BILATERAL.name == "BILATERAL"
-    assert Laterality.UNKNOWN.name == "UNKNOWN"
 
-
-def test_projection_measurement_matrix_laterality():
-    import pytest
-    import connects_common_connectivity as ccc
-    models = ccc.generate_pydantic_models()
-    PMM = models["ProjectionMeasurementMatrix"]
-    Laterality = models["Laterality"]
-    Modality = models["Modality"]
-    PMType = models["ProjectionMeasurementType"]
-    # laterality is required; omitting it should raise
-    with pytest.raises(Exception):
-        PMM(id="P1", measurement_type=PMType.NUMBER_OF_TIPS, modality=Modality.MORPHOLOGY)
-    # Valid laterality values accepted
-    pmm = PMM(id="P1", measurement_type=PMType.NUMBER_OF_TIPS,
-              modality=Modality.MORPHOLOGY, laterality=Laterality.IPSILATERAL)
-    assert str(pmm.laterality) in {Laterality.IPSILATERAL.value, Laterality.IPSILATERAL.name, str(Laterality.IPSILATERAL)}
-    # Invalid laterality should raise
-    with pytest.raises(Exception):
-        PMM(id="P2", measurement_type=PMType.NUMBER_OF_TIPS,
-            modality=Modality.MORPHOLOGY, laterality="NOT_VALID")
-
-
-def test_region_coverage_on_pmm():
-    import connects_common_connectivity as ccc
-    models = ccc.generate_pydantic_models()
-    PMM = models["ProjectionMeasurementMatrix"]
-    Laterality = models["Laterality"]
-    Modality = models["Modality"]
-    PMType = models["ProjectionMeasurementType"]
-    # region_coverage is optional — PMM without it should validate
-    pmm_no_cov = PMM(id="P1", measurement_type=PMType.NUMBER_OF_TIPS,
-                      modality=Modality.MORPHOLOGY, laterality=Laterality.IPSILATERAL,
-                      region_index=["R1", "R2", "R3"])
-    assert pmm_no_cov.region_coverage is None
-    # PMM with region_coverage as subset of region_index
-    pmm_with_cov = PMM(id="P2", measurement_type=PMType.NUMBER_OF_TIPS,
-                        modality=Modality.MORPHOLOGY, laterality=Laterality.CONTRALATERAL,
-                        region_index=["R1", "R2", "R3"],
-                        region_coverage=["R1", "R2"])
-    assert isinstance(pmm_with_cov.region_coverage, list)
-    assert len(pmm_with_cov.region_coverage) == 2
-    assert set(pmm_with_cov.region_coverage).issubset(set(pmm_with_cov.region_index))
 

--- a/tests/test_projection_schema.py
+++ b/tests/test_projection_schema.py
@@ -1,0 +1,53 @@
+import pytest
+from pydantic import ValidationError
+
+import connects_common_connectivity as ccc
+
+
+def test_laterality_enum():
+    models = ccc.generate_pydantic_models()
+    Laterality = models["Laterality"]
+    assert Laterality.IPSILATERAL.name == "IPSILATERAL"
+    assert Laterality.CONTRALATERAL.name == "CONTRALATERAL"
+    assert Laterality.BILATERAL.name == "BILATERAL"
+    assert Laterality.UNKNOWN.name == "UNKNOWN"
+
+
+def test_projection_measurement_matrix_laterality():
+    models = ccc.generate_pydantic_models()
+    PMM = models["ProjectionMeasurementMatrix"]
+    Laterality = models["Laterality"]
+    Modality = models["Modality"]
+    PMType = models["ProjectionMeasurementType"]
+    # laterality is required; omitting it should raise
+    with pytest.raises(ValidationError, match=r"(?s)laterality.*Field required"):
+        PMM(id="P1", measurement_type=PMType.NUMBER_OF_TIPS, modality=Modality.MORPHOLOGY)
+    # Valid laterality values accepted
+    pmm = PMM(id="P1", measurement_type=PMType.NUMBER_OF_TIPS,
+              modality=Modality.MORPHOLOGY, laterality=Laterality.IPSILATERAL)
+    assert str(pmm.laterality) in {Laterality.IPSILATERAL.value, Laterality.IPSILATERAL.name, str(Laterality.IPSILATERAL)}
+    # Invalid laterality should raise
+    with pytest.raises(ValidationError, match=r"(?s)laterality.*Input should be"):
+        PMM(id="P2", measurement_type=PMType.NUMBER_OF_TIPS,
+            modality=Modality.MORPHOLOGY, laterality="NOT_VALID")
+
+
+def test_region_coverage_on_pmm():
+    models = ccc.generate_pydantic_models()
+    PMM = models["ProjectionMeasurementMatrix"]
+    Laterality = models["Laterality"]
+    Modality = models["Modality"]
+    PMType = models["ProjectionMeasurementType"]
+    # region_coverage is optional — PMM without it should validate
+    pmm_no_cov = PMM(id="P1", measurement_type=PMType.NUMBER_OF_TIPS,
+                      modality=Modality.MORPHOLOGY, laterality=Laterality.IPSILATERAL,
+                      region_index=["R1", "R2", "R3"])
+    assert pmm_no_cov.region_coverage is None
+    # PMM with region_coverage as subset of region_index
+    pmm_with_cov = PMM(id="P2", measurement_type=PMType.NUMBER_OF_TIPS,
+                        modality=Modality.MORPHOLOGY, laterality=Laterality.CONTRALATERAL,
+                        region_index=["R1", "R2", "R3"],
+                        region_coverage=["R1", "R2"])
+    assert isinstance(pmm_with_cov.region_coverage, list)
+    assert len(pmm_with_cov.region_coverage) == 2
+    assert set(pmm_with_cov.region_coverage).issubset(set(pmm_with_cov.region_index))


### PR DESCRIPTION
### Motivation

Projection matrices can be split into ipsilateral/contralateral by naming convention (e.g., `wnm_exc_proj_ipsi`), but laterality is not captured in the schema, making it unqueryable.

Similarly, determining which CCF regions a dataset has projection data in requires loading the full cells × regions matrix and checking for non-zero columns. This is a common cross-dataset query that should be precomputed.

### Changes

**`schemas/base_schema.yaml`**
- New `Laterality` enum: `IPSILATERAL`, `CONTRALATERAL`, `BILATERAL`, `UNKNOWN`
- New `laterality` slot with `range: Laterality`

**`schemas/projection_schema.yaml`**
- `laterality`: required field on `ProjectionMeasurementMatrix`
- `region_coverage`: optional multivalued `BrainRegion` list on `ProjectionMeasurementMatrix` — precomputed subset of `region_index` where at least one data item has a non-zero value

**`src/connects_common_connectivity/models.py`**
- Regenerated via `bash scripts/generate_models.sh`

**`tests/test_basic.py`**
- `test_laterality_enum` — all four enum values exist
- `test_projection_measurement_matrix_laterality` — required enforcement, valid/invalid enum validation
- `test_region_coverage_on_pmm` — optional field, list type, subset of `region_index`

**`src/connects_common_connectivity/io/`**
- New module with `io_plans.md` specifying two planned utility functions:
  - `populate_region_coverage(pmm, matrix)` — auto-populate `region_coverage` from a dense values array
  - `compare_region_coverage(pmms)` — shared regions, shared coverage, and exclusive coverage across datasets
  - io utils will be a separate PR

**`.devcontainer/`**
- Added local Docker dev container config (CodeOcean setup unchanged)

**`environment/postInstall`**
- Added CCC package installation

### Testing

9 tests pass (`uv run pytest -q`).